### PR TITLE
Ensure socket is closed immediately on exception

### DIFF
--- a/python/mujinasync/asynctcp.py
+++ b/python/mujinasync/asynctcp.py
@@ -306,6 +306,7 @@ class TcpContext(object):
         # connect for client
         for client in self._clients:
             if not client._connections:
+                clientSocket = None
                 try:
                     clientSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     clientSocket.connect(client._endpoint)
@@ -314,7 +315,9 @@ class TcpContext(object):
                         clientSocket = client._sslContext.wrap_socket(clientSocket, server_side=False)
                     clientSocket.setblocking(0) # TODO: deferred non-blocking after connect finishes, not ideal
                 except Exception as e:
-                    log.exception('error while trying to create client connection: %s', e)
+                    if clientSocket:
+                        clientSocket.close()
+                    log.exception('error while trying to create client connection to %s: %s', client._endpoint, e)
                     continue
                 connection = client._connectionClass(connectionSocket=clientSocket, remoteAddress=client._endpoint)
                 client._connections.append(connection)


### PR DESCRIPTION
Python 2.7 sockets are closed on garbage collect, but this doesn't seem to be the case, at least when reconnect occurs in a hot loop. Instead, we see fd exhaustion or, for ulimit > 1024, `select` errors because 2.7 uses `select` and not `poll`.

Without the fix:
```
2023-10-05 14:29:52,072 mujinasync.asynctcp [INFO] [asynctcp.py:312 SpinOnce] Opened new socket fd 176
2023-10-05 14:29:52,073 mujinasync.asynctcp [ERROR] [commonlogging.py:54 exception] error while trying to create client connection to ('127.0.0.1', 30000): [Errno 111] Connection refused
2023-10-05 14:29:52,134 mujinasync.asynctcp [INFO] [asynctcp.py:312 SpinOnce] Opened new socket fd 177
2023-10-05 14:29:52,134 mujinasync.asynctcp [ERROR] [commonlogging.py:54 exception] error while trying to create client connection to ('127.0.0.1', 30000): [Errno 111] Connection refused
2023-10-05 14:29:52,195 mujinasync.asynctcp [INFO] [asynctcp.py:312 SpinOnce] Opened new socket fd 178
```

with:
```
2023-10-05 14:32:32,352 mujinasync.asynctcp [INFO] [asynctcp.py:312 SpinOnce] Opened new socket fd 109
2023-10-05 14:32:32,353 mujinasync.asynctcp [ERROR] [commonlogging.py:54 exception] error while trying to create client connection to ('127.0.0.1', 30000): [Errno 111] Connection refused
2023-10-05 14:32:32,414 mujinasync.asynctcp [INFO] [asynctcp.py:312 SpinOnce] Opened new socket fd 109
2023-10-05 14:32:32,415 mujinasync.asynctcp [ERROR] [commonlogging.py:54 exception] error while trying to create client connection to ('127.0.0.1', 30000): [Errno 111] Connection refused
2023-10-05 14:32:32,476 mujinasync.asynctcp [INFO] [asynctcp.py:312 SpinOnce] Opened new socket fd 109

```