### PR TITLE
feat(asynctcp.py): use selector module instead of select

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -63,5 +63,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest || true
+        pytest test/
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,32 +10,6 @@ on:
     branches: [ master ]
 
 jobs:
-
-  build_python2:
-    runs-on: ubuntu-20.04
-    container:
-      image: python:2.7.18-buster
-    strategy:
-      matrix:
-        python-version: [2.7]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 pytest
-          pip install .
-
-      - name: Lint with flake8
-        run: |
-          flake8 --isolated --show-source --ignore=C901,E128,E201,E202,E203,E221,E225,E226,E227,E228,E231,E241,E251,E261,E262,E265,E271,E301,E302,E303,E305,E402,E501,W291,W293,W391 python
-
-      - name: Test with pytest
-        run: |
-          pytest test/
-
   build_python3:
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build_python3:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.9]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest || true
+          pytest test/
 
   build_python3:
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest pytest-mock
         pip install .
 
     - name: Lint with flake8

--- a/python/mujinasync/asynctcp.py
+++ b/python/mujinasync/asynctcp.py
@@ -236,12 +236,11 @@ class TcpServer(TcpServerClientBase):
         self._ctx.RegisterServer(self)
 
     def Destroy(self):
-        # should unregister server and server's connection sockets and server sockets before removing
+        self._DestroyServerSocket()
+        super(TcpServer, self).Destroy()
         if self._ctx is not None:
             self._ctx.UnregisterServer(self)
             self._ctx = None
-        self._DestroyServerSocket()
-        super(TcpServer, self).Destroy()
 
     def _EnsureServerSocket(self):
         """Ensure server socket to listen for incoming TCP connections.

--- a/python/mujinasync/asynctcp.py
+++ b/python/mujinasync/asynctcp.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, Optional, Type, Union
 
 log = logging.getLogger(__name__)
 
+TcpServerClient = Union['TcpServer', 'TcpClient']
 
 class TcpBuffer(object):
     """Buffer object to manage socket receive and send
@@ -301,7 +302,7 @@ class TcpContext(object):
 
         :param timeout: in seconds, pass in 0 to not wait for socket events, otherwise, will wait up to specified timeout
         """
-        newConnections: list[tuple[Union[TcpServer, TcpClient], TcpConnection]] = [] # list of tuple (serverClient, connection)
+        newConnections: list[tuple[TcpServerClient, TcpConnection]] = [] # list of tuple (serverClient, connection)
 
         # construct a list of connections to select on
         rsockets: list[socket.socket] = []
@@ -337,7 +338,7 @@ class TcpContext(object):
                 timeout = 0 # force no wait at select later since we have a new connection to report right away
 
         # pool all the sockets
-        socketConnections: dict[socket.socket, tuple[Union[TcpClient, TcpServer], TcpConnection]] = {}
+        socketConnections: dict[socket.socket, tuple[TcpServerClient, TcpConnection]] = {}
         for serverClient in self._servers + self._clients:
             for connection in serverClient._connections:
                 if connection.connectionSocket is None:
@@ -386,7 +387,7 @@ class TcpContext(object):
                     wlist.append(sock)
 
         # handle sockets that can read
-        receivedConnections: list[tuple[Union[TcpServer, TcpClient], TcpConnection]] = [] # list of tuple (serverClient, connection)
+        receivedConnections: list[tuple[TcpServerClient, TcpConnection]] = [] # list of tuple (serverClient, connection)
         for rsocket in rlist:
             server = serverSockets.get(rsocket)
             if server is not None:
@@ -446,7 +447,7 @@ class TcpContext(object):
 
 
         # handle closed connections
-        closeConnections = [] # list of tuple (serverClient, connection)
+        closeConnections: list[tuple[TcpServerClient, TcpConnection]] = [] # list of tuple (serverClient, connection)
         for serverClient in self._servers + self._clients:
             for connection in serverClient._connections:
                 if connection.closeType == 'Immediate':

--- a/python/mujinasync/asynctcp.py
+++ b/python/mujinasync/asynctcp.py
@@ -7,7 +7,7 @@ import socket
 import ssl
 
 import logging
-from typing import Literal, Optional, Type, Union
+from typing import Any, Literal, Optional, Type, Union
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class TcpBuffer(object):
         return self._size
 
     @size.setter
-    def size(self, size):
+    def size(self, size: int):
         if size < 0 or size > len(self._data):
             raise IndexError
         if size < self._size:
@@ -55,7 +55,7 @@ class TcpBuffer(object):
         return len(self._data)
 
     @capacity.setter
-    def capacity(self, capacity):
+    def capacity(self, capacity: int):
         if capacity < self._size:
             raise IndexError
         data = bytearray(capacity)
@@ -69,13 +69,13 @@ class TcpConnection(object):
     """
 
     connectionSocket: Optional[socket.socket] # accepted socket object
-    remoteAddress = None # remote address
+    remoteAddress: tuple[str, int] # remote address
     closeType: Optional[Union[Literal['AfterSend'], Literal['Immediate']]] = None # Immediate, AfterSend
     sendBuffer: TcpBuffer # buffer to hold data waiting to be sent
     receiveBuffer: TcpBuffer # buffer to hold data received before consumption
     hasPendingWork: bool = False # should this socket be submitted as a 'readable' socket even if no new data is received?
 
-    def __init__(self, connectionSocket, remoteAddress):
+    def __init__(self, connectionSocket: socket.socket, remoteAddress: tuple[str, int]):
         self.connectionSocket = connectionSocket
         self.remoteAddress = remoteAddress
         self.closeType = None
@@ -94,7 +94,7 @@ class TcpServerClientBase(object):
 
     _ctx: Optional['TcpContext'] # a TcpContext
     _endpoint: tuple[str, int] # connection endpoint, should be a tuple (host, port)
-    _api = None # an optional api object to receive callback on
+    _api: Optional[Any] = None # an optional api object to receive callback on
     _connectionClass: Type[TcpConnection] # class to hold accepted connection data
     _connections: list[TcpConnection] # a list of instances of connectionClass
     _sslContext: Optional[ssl.SSLContext] = None  # a ssl.SSLContext
@@ -204,8 +204,8 @@ class TcpServer(TcpServerClientBase):
     TCP server base.
     """
     _serverSocket: Optional[socket.socket] = None # listening socket
-    _backlog = 5 # number of connection to backlog before accepting
-    _resuseAddress = True # allow reuse of TCP port
+    _backlog: int = 5 # number of connection to backlog before accepting
+    _resuseAddress: bool = True # allow reuse of TCP port
 
     def __init__(self, ctx, endpoint, api=None, connectionClass=TcpConnection, sslKeyCert=None):
         """Create a TCP server.

--- a/test/test_asynctcp.py
+++ b/test/test_asynctcp.py
@@ -203,7 +203,7 @@ class TestAsyncTcp:
         server = TcpServer(ctx, serverEndpoint)
         server._EnsureServerSocket()
 
-        clients = []
+        clients: list[TcpClient] = []
         for i in range(3):
             client = TcpClient(ctx, serverEndpoint)
             clients.append(client)

--- a/test/test_asynctcp.py
+++ b/test/test_asynctcp.py
@@ -1,11 +1,11 @@
 import errno
 import socket
 
-import pytest
 from pytest_mock import MockerFixture
 from python.mujinasync.asynctcp import TcpClient, TcpContext, TcpServer
 
-TIMEOUT = 0.05
+TIMEOUT = 0.01
+MAX_RETRY_ATTEMPTS = 10
 
 
 class TestAsyncTcp:
@@ -20,7 +20,7 @@ class TestAsyncTcp:
         client = TcpClient(ctx, endpoint)
 
         connected = False
-        for _ in range(20):
+        for _ in range(MAX_RETRY_ATTEMPTS):
             ctx.SpinOnce(timeout=TIMEOUT)
             if len(server._connections) > 0 and len(client._connections) > 0:
                 connected = True
@@ -44,7 +44,7 @@ class TestAsyncTcp:
 
         testData = b"Hello Server!"
 
-        for _ in range(10):
+        for _ in range(MAX_RETRY_ATTEMPTS):
             ctx.SpinOnce(timeout=TIMEOUT)
             if len(server._connections) > 0 and len(client._connections) > 0:
                 break
@@ -54,7 +54,7 @@ class TestAsyncTcp:
             connection.sendBuffer.writeView[: len(testData)] = testData
             connection.sendBuffer.size = len(testData)
 
-        for _ in range(10):
+        for _ in range(MAX_RETRY_ATTEMPTS):
             ctx.SpinOnce(timeout=TIMEOUT)
             if server._connections and server._connections[0].receiveBuffer.size > 0:
                 break
@@ -70,42 +70,16 @@ class TestAsyncTcp:
         server.Destroy()
         client.Destroy()
 
-    def test_MultipleClients(self) -> None:
+    def test_Handle_EAGAIN_OnSend(self, mocker: MockerFixture) -> None:
+        """Test EAGAIN / EWOULDBLOCK handling on send"""
         ctx = TcpContext()
         endpoint = ("127.0.0.1", 12347)
 
         server = TcpServer(ctx, endpoint)
         server._EnsureServerSocket()
-
-        # Create 3 clients one by one
-        for _ in range(3):
-            client = TcpClient(ctx, endpoint)
-
-            for _ in range(10):
-                ctx.SpinOnce(timeout=TIMEOUT)
-                if len(client._connections) > 0:
-                    break
-
-        assert len(server._connections) == 3
-        connectedClients = sum(
-            1 for client in ctx._clients if len(client._connections) > 0
-        )
-        assert connectedClients == 3
-
-        for client in ctx._clients:
-            client.Destroy()
-        server.Destroy()
-
-    def test_Handle_EAGAIN_OnSend(self, mocker: MockerFixture) -> None:
-        """Test EAGAIN / EWOULDBLOCK handling on send"""
-        ctx = TcpContext()
-        endpoint = ("127.0.0.1", 12348)
-
-        server = TcpServer(ctx, endpoint)
-        server._EnsureServerSocket()
         client = TcpClient(ctx, endpoint)
 
-        for _ in range(10):
+        for _ in range(MAX_RETRY_ATTEMPTS):
             ctx.SpinOnce(timeout=TIMEOUT)
             if len(server._connections) > 0 and len(client._connections) > 0:
                 break
@@ -159,13 +133,13 @@ class TestAsyncTcp:
     def test_Handle_EAGAIN_OnRecv(self, mocker: MockerFixture) -> None:
         """Test EAGAIN / EWOULDBLOCK handling on recv_into"""
         ctx = TcpContext()
-        endpoint = ("127.0.0.1", 12349)
+        endpoint = ("127.0.0.1", 12348)
 
         server = TcpServer(ctx, endpoint)
         server._EnsureServerSocket()
         client = TcpClient(ctx, endpoint)
 
-        for _ in range(10):
+        for _ in range(MAX_RETRY_ATTEMPTS):
             ctx.SpinOnce(timeout=TIMEOUT)
             if len(server._connections) > 0 and len(client._connections) > 0:
                 break
@@ -220,3 +194,151 @@ class TestAsyncTcp:
 
         server.Destroy()
         client.Destroy()
+
+    def test_DynamicServerClientAddRemoval(self) -> None:
+        """Test dynamic addition and removal of servers and clients"""
+        ctx = TcpContext()
+
+        serverEndpoint = ("127.0.0.1", 12349)
+        server = TcpServer(ctx, serverEndpoint)
+        server._EnsureServerSocket()
+
+        clients = []
+        for i in range(3):
+            client = TcpClient(ctx, serverEndpoint)
+            clients.append(client)
+
+            for _ in range(MAX_RETRY_ATTEMPTS):
+                ctx.SpinOnce(timeout=TIMEOUT)
+                if len(client._connections) > 0:
+                    break
+
+            assert len(server._connections) == i + 1, (
+                f"After adding client {i}, server should have {i + 1} connections"
+            )
+
+        for i in range(3):
+            client = clients.pop()
+            client.Destroy()
+
+            for _ in range(MAX_RETRY_ATTEMPTS):
+                ctx.SpinOnce(timeout=TIMEOUT)
+
+            expectedConnections = 3 - i - 1
+            assert len(server._connections) == expectedConnections, (
+                f"After removing client, server should have {expectedConnections} connections"
+            )
+
+        server2Endpoint = ("127.0.0.1", 12350)
+        server2 = TcpServer(ctx, server2Endpoint)
+        server2._EnsureServerSocket()
+
+        client1 = TcpClient(ctx, serverEndpoint)
+        client2 = TcpClient(ctx, server2Endpoint)
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if (
+                len(server._connections) > 0
+                and len(server2._connections) > 0
+                and len(client1._connections) > 0
+                and len(client2._connections) > 0
+            ):
+                break
+
+        assert len(server._connections) == 1, "Original server should have 1 connection"
+        assert len(server2._connections) == 1, "New server should have 1 connection"
+
+        # Remove first server while keeping second
+        server.Destroy()
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+
+        # Second server should still work
+        assert len(server2._connections) == 1, (
+            "Second server should still have its connection"
+        )
+        assert len(client2._connections) == 1, (
+            "Client to second server should still be connected"
+        )
+
+        # Cleanup
+        client1.Destroy()
+        client2.Destroy()
+        server2.Destroy()
+
+    def test_MultipleServersMultipleClients(self) -> None:
+        """Test multiple servers with multiple clients connecting to each"""
+        SERVER_COUNT = 10
+        CLIENT_PER_SERVER = 5
+        ctx = TcpContext()
+
+        assert ctx._selector
+
+        servers = []
+        for i in range(SERVER_COUNT):
+            endpoint = ("127.0.0.1", 12351 + i)
+            server = TcpServer(ctx, endpoint)
+            server._EnsureServerSocket()
+            servers.append(server)
+
+        clients = []
+        for server in servers:
+            for _ in range(CLIENT_PER_SERVER):
+                client = TcpClient(ctx, server._endpoint)
+                clients.append(client)
+
+        initialRegisteredSockets = len(ctx._selector.get_map())
+
+        # Process CLIENT_PER_SERVER clients at a time
+        for i in range(0, len(clients), CLIENT_PER_SERVER):
+            for _ in range(MAX_RETRY_ATTEMPTS):
+                ctx.SpinOnce(timeout=TIMEOUT)
+
+            # The number of registered sockets should grow as connections are added
+            currentRegistered = len(ctx._selector.get_map())
+            assert currentRegistered >= initialRegisteredSockets, (
+                "Registered sockets should increase or stay same"
+            )
+
+        totalConnections = sum(len(server._connections) for server in servers)
+        assert totalConnections == SERVER_COUNT * CLIENT_PER_SERVER, (
+            f"Expected {SERVER_COUNT * CLIENT_PER_SERVER} total connections, got {totalConnections}"
+        )
+
+        finalRegistered = len(ctx._selector.get_map())
+        expectedSockets = SERVER_COUNT + totalConnections
+        assert finalRegistered >= expectedSockets, (
+            f"Should have at least {expectedSockets} registered sockets, got {finalRegistered}"
+        )
+
+        testData = b"Multi server/client test data"
+        messagesSent = 0
+
+        # Send data from last client for each server to create mixed read/write activity
+        for i in range(0, len(clients), CLIENT_PER_SERVER):
+            client = clients[i]
+            if client._connections:
+                conn = client._connections[0]
+                conn.sendBuffer.writeView[: len(testData)] = testData
+                conn.sendBuffer.size = len(testData)
+                messagesSent += 1
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+
+        messages_received = 0
+        for server in servers:
+            for conn in server._connections:
+                if conn.receiveBuffer.size > 0:
+                    messages_received += 1
+
+        assert messages_received == messagesSent, (
+            f"Expected {messagesSent} messages received, got {messages_received}"
+        )
+
+        for client in clients:
+            client.Destroy()
+        for server in servers:
+            server.Destroy()

--- a/test/test_asynctcp.py
+++ b/test/test_asynctcp.py
@@ -1,0 +1,222 @@
+import errno
+import socket
+
+import pytest
+from pytest_mock import MockerFixture
+from python.mujinasync.asynctcp import TcpClient, TcpContext, TcpServer
+
+TIMEOUT = 0.05
+
+
+class TestAsyncTcp:
+    def test_ClientSserverConnection(self) -> None:
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12345)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+        assert server._serverSocket is not None, "Server should be listening"
+
+        client = TcpClient(ctx, endpoint)
+
+        connected = False
+        for _ in range(20):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                connected = True
+                break
+
+        assert connected, "Connection should be established"
+        assert len(server._connections) == 1, "Server should have 1 client connection"
+        assert len(client._connections) == 1, "Client should have 1 server connection"
+
+        server.Destroy()
+        client.Destroy()
+
+    def test_DataExchange(self) -> None:
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12346)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+
+        client = TcpClient(ctx, endpoint)
+
+        testData = b"Hello Server!"
+
+        for _ in range(10):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                break
+
+        if client._connections:
+            connection = client._connections[0]
+            connection.sendBuffer.writeView[: len(testData)] = testData
+            connection.sendBuffer.size = len(testData)
+
+        for _ in range(10):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if server._connections and server._connections[0].receiveBuffer.size > 0:
+                break
+
+        assert len(server._connections) > 0
+        serverConnection = server._connections[0]
+        clientConnection = client._connections[0]
+        assert serverConnection.receiveBuffer.size > 0
+        assert clientConnection.sendBuffer.size < len(testData)
+        received_data = bytes(serverConnection.receiveBuffer.readView)
+        assert received_data == testData
+
+        server.Destroy()
+        client.Destroy()
+
+    def test_MultipleClients(self) -> None:
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12347)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+
+        # Create 3 clients one by one
+        for _ in range(3):
+            client = TcpClient(ctx, endpoint)
+
+            for _ in range(10):
+                ctx.SpinOnce(timeout=TIMEOUT)
+                if len(client._connections) > 0:
+                    break
+
+        assert len(server._connections) == 3
+        connectedClients = sum(
+            1 for client in ctx._clients if len(client._connections) > 0
+        )
+        assert connectedClients == 3
+
+        for client in ctx._clients:
+            client.Destroy()
+        server.Destroy()
+
+    def test_Handle_EAGAIN_OnSend(self, mocker: MockerFixture) -> None:
+        """Test EAGAIN / EWOULDBLOCK handling on send"""
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12348)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+        client = TcpClient(ctx, endpoint)
+
+        for _ in range(10):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                break
+
+        if client._connections:
+            connection = client._connections[0]
+            testData = b"Test data for EAGAIN"
+            connection.sendBuffer.writeView[: len(testData)] = testData
+            connection.sendBuffer.size = len(testData)
+
+            callCount = 0
+
+            def MockSend(data):
+                nonlocal callCount
+                callCount += 1
+                if callCount == 1:
+                    error = socket.error()
+                    error.errno = errno.EAGAIN
+                    raise error
+                elif callCount == 2:
+                    error = socket.error()
+                    error.errno = errno.EWOULDBLOCK
+                    raise error
+                else:
+                    # For the successful call, we need to return a reasonable value
+                    return len(data)
+
+            mockSocketSend = mocker.patch.object(
+                socket.socket, "send", side_effect=MockSend
+            )
+
+            # First call: EAGAIN
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert connection.closeType is None
+            assert connection.sendBuffer.size == len(testData)
+
+            # Second call: EWOULDBLOCK
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert connection.closeType is None
+            assert connection.sendBuffer.size == len(testData)
+
+            # Third call: original result (should succeed)
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert connection.sendBuffer.size == 0
+
+            assert mockSocketSend.call_count == 3
+
+        server.Destroy()
+        client.Destroy()
+
+    def test_Handle_EAGAIN_OnRecv(self, mocker: MockerFixture) -> None:
+        """Test EAGAIN / EWOULDBLOCK handling on recv_into"""
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12349)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+        client = TcpClient(ctx, endpoint)
+
+        for _ in range(10):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                break
+
+        if client._connections and server._connections:
+            clientConnection = client._connections[0]
+            test_data = b"Test data"
+            clientConnection.sendBuffer.writeView[: len(test_data)] = test_data
+            clientConnection.sendBuffer.size = len(test_data)
+
+            # Let data be sent first
+            ctx.SpinOnce(timeout=TIMEOUT)
+
+            serverConnection = server._connections[0]
+
+            callCount = 0
+
+            def MockRecvInto(buffer):
+                nonlocal callCount
+                callCount += 1
+                if callCount == 1:
+                    error = socket.error()
+                    error.errno = errno.EAGAIN
+                    raise error
+                elif callCount == 2:
+                    error = socket.error()
+                    error.errno = errno.EWOULDBLOCK
+                    raise error
+                else:
+                    # For the successful call, simulate receiving some data
+                    test_response = b"response"
+                    buffer[: len(test_response)] = test_response
+                    return len(test_response)
+
+            mockSocketRecv = mocker.patch.object(
+                socket.socket, "recv_into", side_effect=MockRecvInto
+            )
+
+            # First call: EAGAIN
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert serverConnection.closeType is None
+
+            # Second call: EWOULDBLOCK
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert serverConnection.closeType is None
+
+            # Third call: should work normally
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert serverConnection.closeType is None
+
+            assert mockSocketRecv.call_count >= 2
+
+        server.Destroy()
+        client.Destroy()


### PR DESCRIPTION
- Use selector module instead of select, fix `FD_SETSIZE` limitation. The `selector.DefaultSelector()` will try to use `epoll` if avaliable.
- Remove `xsockets` and `xlist` since we are using `selector` module, there is no handler for `xlist`
- Add error check when calling `wsocket.send()`, when encounter `EAGAIN` or `EWOULDBLOCK`, we should not close the socket.
- Tweak typing in `asynctcp.py`, now pyright won't give any typing error in this file
- Add test code
