### PR TITLE
feat(asynctcp.py): use selector module instead of select

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,35 +10,9 @@ on:
     branches: [ master ]
 
 jobs:
-
-  build_python2:
-    runs-on: ubuntu-20.04
-    container:
-      image: python:2.7.18-buster
-    strategy:
-      matrix:
-        python-version: [2.7]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 pytest
-          pip install .
-
-      - name: Lint with flake8
-        run: |
-          flake8 --isolated --show-source --ignore=C901,E128,E201,E202,E203,E221,E225,E226,E227,E228,E231,E241,E251,E261,E262,E265,E271,E301,E302,E303,E305,E402,E501,W291,W293,W391 python
-
-      - name: Test with pytest
-        run: |
-          pytest || true
-
   build_python3:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.9]
@@ -54,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest pytest-mock
         pip install .
 
     - name: Lint with flake8
@@ -63,5 +37,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest || true
+        pytest test/
 

--- a/python/mujinasync/asynctcp.py
+++ b/python/mujinasync/asynctcp.py
@@ -362,7 +362,7 @@ class TcpContext(object):
         except (OSError, ValueError, KeyError) as e:
             log.warning('failed to unregister unused socket %s: %s', sock, e)
 
-    def SpinOnce(self, timeout=0):
+    def SpinOnce(self, timeout:float = 0):
         """Spin all sockets once, without creating threads.
 
         :param timeout: in seconds, pass in 0 to not wait for socket events, otherwise, will wait up to specified timeout
@@ -416,7 +416,7 @@ class TcpContext(object):
         # wait for events
         while True:
             try:
-                events = self._selector.select(timeout if timeout > 0 else None)
+                events = self._selector.select(timeout)
                 break
             except (OSError, select.error) as e:
                 if e.args[0] != errno.EINTR:

--- a/python/mujinasync/asynctcp.py
+++ b/python/mujinasync/asynctcp.py
@@ -2,19 +2,23 @@
 
 import errno
 import select
+import selectors
 import socket
 import ssl
 
 import logging
+from typing import Any, Literal, Optional, Type, Union
+
 log = logging.getLogger(__name__)
 
+TcpServerClient = Union['TcpServer', 'TcpClient']
 
 class TcpBuffer(object):
     """Buffer object to manage socket receive and send
     """
 
-    _data = None
-    _size = 0
+    _data: bytearray
+    _size: int = 0
 
     def __init__(self):
         self._data = bytearray(64 * 1024)
@@ -38,7 +42,7 @@ class TcpBuffer(object):
         return self._size
 
     @size.setter
-    def size(self, size):
+    def size(self, size: int):
         if size < 0 or size > len(self._data):
             raise IndexError
         if size < self._size:
@@ -52,7 +56,7 @@ class TcpBuffer(object):
         return len(self._data)
 
     @capacity.setter
-    def capacity(self, capacity):
+    def capacity(self, capacity: int):
         if capacity < self._size:
             raise IndexError
         data = bytearray(capacity)
@@ -65,14 +69,14 @@ class TcpConnection(object):
     Accepted TCP connection.
     """
 
-    connectionSocket = None # accepted socket object
-    remoteAddress = None # remote address
-    closeType = None # Immediate, AfterSend
-    sendBuffer = None # buffer to hold data waiting to be sent
-    receiveBuffer = None # buffer to hold data received before consumption
+    connectionSocket: Optional[socket.socket] # accepted socket object
+    remoteAddress: tuple[str, int] # remote address
+    closeType: Optional[Union[Literal['AfterSend'], Literal['Immediate']]] = None # Immediate, AfterSend
+    sendBuffer: TcpBuffer # buffer to hold data waiting to be sent
+    receiveBuffer: TcpBuffer # buffer to hold data received before consumption
     hasPendingWork: bool = False # should this socket be submitted as a 'readable' socket even if no new data is received?
 
-    def __init__(self, connectionSocket, remoteAddress):
+    def __init__(self, connectionSocket: socket.socket, remoteAddress: tuple[str, int]):
         self.connectionSocket = connectionSocket
         self.remoteAddress = remoteAddress
         self.closeType = None
@@ -89,12 +93,12 @@ class TcpConnection(object):
 
 class TcpServerClientBase(object):
 
-    _ctx = None # a TcpContext
-    _endpoint = None # connection endpoint, should be a tuple (host, port)
-    _api = None # an optional api object to receive callback on
-    _connectionClass = None # class to hold accepted connection data
-    _connections = None # a list of instances of connectionClass
-    _sslContext = None  # a ssl.SSLContext
+    _ctx: Optional['TcpContext'] # a TcpContext
+    _endpoint: tuple[str, int] # connection endpoint, should be a tuple (host, port)
+    _api: Optional[Any] = None # an optional api object to receive callback on
+    _connectionClass: Type[TcpConnection] # class to hold accepted connection data
+    _connections: list[TcpConnection] # a list of instances of connectionClass
+    _sslContext: Optional[ssl.SSLContext] = None  # a ssl.SSLContext
 
     def __init__(self, ctx, endpoint, api=None, connectionClass=TcpConnection, sslContext=None):
         """Create a TCP client.
@@ -116,19 +120,36 @@ class TcpServerClientBase(object):
     def Destroy(self):
         self._CloseAllConnections()
 
+    def _CloseConnection(self, connection: TcpConnection) -> None:
+        """ Close a connected connection
+        1. Unregister its connectionSocket from context's selector
+        2. Shutdown and close the socket
+        3. Remove this connection from self._connections
+        """
+        if connection not in self._connections:
+            return
+        if connection.connectionSocket is not None:
+            try:
+                if self._ctx is not None:
+                    self._ctx._UnregisterSocket(connection.connectionSocket)
+                try:
+                    connection.connectionSocket.shutdown(socket.SHUT_RDWR)
+                except OSError as e:
+                    # Socket may already be disconnected
+                    if e.errno not in (errno.ENOTCONN, errno.EBADF):
+                        raise
+                connection.connectionSocket.close()
+            except Exception as e:
+                log.exception('failed to close connection socket: %s', e)
+            connection.connectionSocket = None
+        self._connections.remove(connection)
+
     def _CloseAllConnections(self):
         """Close all connected connections
         """
-        connections = self._connections
-        self._connections = []
+        connections = list(self._connections)  # Make a copy to avoid modification during iteration
         for connection in connections:
-            if connection.connectionSocket is not None:
-                try:
-                    connection.connectionSocket.shutdown(socket.SHUT_RDWR)
-                    connection.connectionSocket.close()
-                except Exception as e:
-                    log.exception('failed to close connection socket: %s', e)
-                connection.connectionSocket = None
+            self._CloseConnection(connection)
         for connection in connections:
             self._HandleTcpDisconnect(connection)
 
@@ -186,6 +207,7 @@ class TcpClient(TcpServerClientBase):
             if sslKeyCert is not None:
                 sslContext.load_cert_chain(sslKeyCert)
         super(TcpClient, self).__init__(ctx, endpoint=endpoint, api=api, connectionClass=connectionClass, sslContext=sslContext)
+        assert self._ctx
         self._ctx.RegisterClient(self)
 
     def Destroy(self):
@@ -199,9 +221,9 @@ class TcpServer(TcpServerClientBase):
     """
     TCP server base.
     """
-    _serverSocket = None # listening socket
-    _backlog = 5 # number of connection to backlog before accepting
-    _resuseAddress = True # allow reuse of TCP port
+    _serverSocket: Optional[socket.socket] = None # listening socket
+    _backlog: int = 5 # number of connection to backlog before accepting
+    _resuseAddress: bool = True # allow reuse of TCP port
 
     def __init__(self, ctx, endpoint, api=None, connectionClass=TcpConnection, sslKeyCert=None):
         """Create a TCP server.
@@ -215,6 +237,7 @@ class TcpServer(TcpServerClientBase):
             sslContext = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             sslContext.load_cert_chain(sslKeyCert)
         super(TcpServer, self).__init__(ctx, endpoint=endpoint, api=api, connectionClass=connectionClass, sslContext=sslContext)
+        assert self._ctx
         self._ctx.RegisterServer(self)
 
     def Destroy(self):
@@ -234,10 +257,12 @@ class TcpServer(TcpServerClientBase):
                 serverSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 if self._resuseAddress:
                     serverSocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                serverSocket.setblocking(0)
+                serverSocket.setblocking(False)
                 serverSocket.bind(self._endpoint)
                 serverSocket.listen(self._backlog)
                 self._serverSocket = serverSocket
+                assert self._ctx
+                self._ctx._RegisterSocket(self._serverSocket, selectors.EVENT_READ)
                 serverSocket = None
                 log.debug('server socket listening on %s:%d', self._endpoint[0], self._endpoint[1])
             except Exception as e:
@@ -255,6 +280,8 @@ class TcpServer(TcpServerClientBase):
         """
         if self._serverSocket is not None:
             try:
+                if self._ctx is not None:
+                    self._ctx._UnregisterSocket(self._serverSocket)
                 self._serverSocket.close()
             except Exception as e:
                 log.exception('failed to close server socket: %s', e)
@@ -262,55 +289,94 @@ class TcpServer(TcpServerClientBase):
 
 class TcpContext(object):
 
-    _servers = None # list of TcpServer
-    _clients = None # lits of TcpClient
+    _servers: list[TcpServer] # list of TcpServer
+    _clients: list[TcpClient] # lits of TcpClient
+    _selector: Optional[selectors.DefaultSelector] # selector, on Debian it will be EpollSelector
+    _registeredSocketMaskBySocket: dict[socket.socket, int] # dict of socket -> socketMask(int)
 
     def __init__(self):
         self._servers = []
         self._clients = []
+        self._selector = selectors.DefaultSelector()
+        self._registeredSocketMaskBySocket = {}
 
     def __del__(self):
         self.Destroy()
 
     def Destroy(self):
+        if self._selector is not None:
+            self._selector.close()
+            self._selector = None
         self._servers = []
 
-    def RegisterServer(self, server):
+    def RegisterServer(self, server: TcpServer):
         if server not in self._servers:
             self._servers.append(server)
 
-    def UnregisterServer(self, server):
+    def UnregisterServer(self, server: TcpServer):
         if server in self._servers:
             self._servers.remove(server)
 
-    def RegisterClient(self, client):
+    def RegisterClient(self, client: TcpClient):
         if client not in self._clients:
             self._clients.append(client)
 
-    def UnregisterClient(self, client):
+    def UnregisterClient(self, client: TcpClient):
         if client in self._clients:
             self._clients.remove(client)
+
+    def _RegisterSocket(self, sock: socket.socket, mask: int) -> None:
+        """
+        Register socket to selector
+        Should be called when socket is created
+        """
+        assert self._selector, "selector is not ready"
+        existingMask = self._registeredSocketMaskBySocket.get(sock)
+        if existingMask == mask:
+            return
+
+        try:
+            if existingMask is None:
+                # register new socket to selector
+                self._selector.register(sock, mask, data=sock)
+            else:
+                # update exisiting socket in selector
+                self._selector.modify(sock, mask, data=sock)
+            self._registeredSocketMaskBySocket[sock] = mask
+        except (OSError, ValueError) as e:
+            log.warning('failed to register socket %s: %s', sock, e)
+
+    def _UnregisterSocket(self, sock: socket.socket) -> None:
+        """
+        Unregister socket from selector
+        Should be called when socket is destoryed
+        """
+        existingMask = self._registeredSocketMaskBySocket.get(sock)
+        if existingMask is None:
+            return
+
+        try:
+            if self._selector:
+                self._selector.unregister(sock)
+            self._registeredSocketMaskBySocket.pop(sock)
+        except (OSError, ValueError, KeyError) as e:
+            log.warning('failed to unregister unused socket %s: %s', sock, e)
 
     def SpinOnce(self, timeout=0):
         """Spin all sockets once, without creating threads.
 
         :param timeout: in seconds, pass in 0 to not wait for socket events, otherwise, will wait up to specified timeout
         """
-        newConnections = [] # list of tuple (serverClient, connection)
-
-        # construct a list of connections to select on
-        rsockets = []
-        wsockets = []
-        xsockets = []
+        assert self._selector, "selector is not ready"
+        newConnections: list[tuple[TcpServerClient, TcpConnection]] = [] # list of tuple (serverClient, connection)
+        socketConnections: dict[socket.socket, tuple[TcpServerClient, TcpConnection]] = {} # Track socket->connection mapping and server sockets
 
         # bind and listen for server
-        serverSockets = {} # map from serverSocket to server
+        tcpServersBySocket: dict[socket.socket, TcpServer] = {} # map from serverSocket to server
         for server in self._servers:
             server._EnsureServerSocket()
             if server._serverSocket is not None:
-                serverSockets[server._serverSocket] = server
-                rsockets.append(server._serverSocket)
-                xsockets.append(server._serverSocket)
+                tcpServersBySocket[server._serverSocket] = server
 
         # connect for client
         for client in self._clients:
@@ -322,7 +388,7 @@ class TcpContext(object):
                         clientSocket = client._sslContext.wrap_socket(clientSocket, server_side=False)
                     clientSocket.connect(client._endpoint)
                     log.debug('new connection to %s', client._endpoint)
-                    clientSocket.setblocking(0) # TODO: deferred non-blocking after connect finishes, not ideal
+                    clientSocket.setblocking(False) # TODO: deferred non-blocking after connect finishes, not ideal
                 except Exception as e:
                     if clientSocket:
                         clientSocket.close()
@@ -334,37 +400,50 @@ class TcpContext(object):
                 timeout = 0 # force no wait at select later since we have a new connection to report right away
 
         # pool all the sockets
-        socketConnections = {}
         for serverClient in self._servers + self._clients:
             for connection in serverClient._connections:
+                if connection.connectionSocket is None:
+                    continue
                 if connection.receiveBuffer.size >= connection.receiveBuffer.capacity:
                     connection.receiveBuffer.capacity *= 2
-                rsockets.append(connection.connectionSocket)
+                mask = selectors.EVENT_READ
                 if connection.sendBuffer.size > 0:
-                    wsockets.append(connection.connectionSocket)
-                xsockets.append(connection.connectionSocket)
-                socketConnections[connection.connectionSocket] = (serverClient, connection)
-
-        # select
+                    mask |= selectors.EVENT_WRITE
+                sock = connection.connectionSocket
+                self._RegisterSocket(sock, mask)
+                socketConnections[sock] = (serverClient, connection)
+        
+        # wait for events
         while True:
             try:
-                rlist, wlist, xlist = select.select(rsockets, wsockets, xsockets, timeout)
+                events = self._selector.select(timeout if timeout > 0 else None)
                 break
             except (OSError, select.error) as e:
                 if e.args[0] != errno.EINTR:
                     raise
+        
+        # keep select-style
+        rlist: list[socket.socket] = []
+        wlist: list[socket.socket] = []
+        for key, mask in events:
+            sock = key.data
+            if mask & selectors.EVENT_READ:
+                rlist.append(sock)
+            if mask & selectors.EVENT_WRITE:
+                wlist.append(sock)
 
         # handle sockets that can read
-        receivedConnections = [] # list of tuple (serverClient, connection)
+        receivedConnections: list[tuple[TcpServerClient, TcpConnection]] = [] # list of tuple (serverClient, connection)
         for rsocket in rlist:
-            server = serverSockets.get(rsocket)
+            server = tcpServersBySocket.get(rsocket)
             if server is not None:
                 try:
+                    assert server._serverSocket
                     connectionSocket, remoteAddress = server._serverSocket.accept()
                     log.debug('new connection from %s on endpoint %s', remoteAddress, server._endpoint)
                     if server._sslContext is not None:
                         connectionSocket = server._sslContext.wrap_socket(connectionSocket, server_side=True)
-                    connectionSocket.setblocking(0)
+                    connectionSocket.setblocking(False)
                 except Exception as e:
                     log.exception('error while trying to accept connection: %s', e)
                     continue
@@ -373,6 +452,8 @@ class TcpContext(object):
                 newConnections.append((server, connection))
                 continue
 
+            if rsocket not in socketConnections:
+                continue  # socket was removed during cleanup
             serverClient, connection = socketConnections[rsocket]
             try:
                 received = rsocket.recv_into(connection.receiveBuffer.writeView)
@@ -396,10 +477,17 @@ class TcpContext(object):
 
         # handle sockets that can write
         for wsocket in wlist:
+            if wsocket not in socketConnections:
+                continue  # socket was removed during cleanup
             serverClient, connection = socketConnections[wsocket]
             if connection.sendBuffer.size > 0:
                 try:
                     sent = wsocket.send(connection.sendBuffer.readView)
+                except socket.error as e:
+                    if e.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                        connection.closeType = 'Immediate'
+                        log.exception('error while trying to send on connection %s: %s', connection, e)
+                    continue
                 except Exception as e:
                     connection.closeType = 'Immediate'
                     log.exception('error while trying to send on connection %s: %s', connection, e)
@@ -407,20 +495,9 @@ class TcpContext(object):
                 if sent > 0:
                     connection.sendBuffer.size -= sent
 
-        # handle sockets with exceptions
-        for xsocket in xlist:
-            server = serverSockets.get(rsocket)
-            if server is not None:
-                log.error('error in server socket, will recreate')
-                server._DestroyServerSocket()
-                continue
-
-            serverClient, connection = socketConnections[wsocket]
-            connection.closeType = 'Immediate'
-            log.error('error in connection, maybe closed: %s', connection)
 
         # handle closed connections
-        closeConnections = [] # list of tuple (serverClient, connection)
+        closeConnections: list[tuple[TcpServerClient, TcpConnection]] = [] # list of tuple (serverClient, connection)
         for serverClient in self._servers + self._clients:
             for connection in serverClient._connections:
                 if connection.closeType == 'Immediate':
@@ -428,15 +505,8 @@ class TcpContext(object):
                 elif connection.closeType == 'AfterSend' and connection.sendBuffer.size == 0:
                     closeConnections.append((serverClient, connection))
         for serverClient, connection in closeConnections:
-            if connection.connectionSocket is not None:
-                log.debug('closing connection from %s on endpoint %s', connection.remoteAddress, serverClient._endpoint)
-                try:
-                    connection.connectionSocket.shutdown(socket.SHUT_RDWR)
-                    connection.connectionSocket.close()
-                except Exception as e:
-                    log.exception('failed to close connection socket: %s', e)
-                connection.connectionSocket = None
-            serverClient._connections.remove(connection)
+            log.debug('closing connection from %s on endpoint %s', connection.remoteAddress, serverClient._endpoint)
+            serverClient._CloseConnection(connection)
 
         # Handle server sockets that are processing non-blocking work
         for server in self._servers:

--- a/test/test_asynctcp.py
+++ b/test/test_asynctcp.py
@@ -1,0 +1,473 @@
+import errno
+import socket
+
+from pytest_mock import MockerFixture
+from python.mujinasync.asynctcp import TcpClient, TcpContext, TcpServer
+
+TIMEOUT = 0.01
+MAX_RETRY_ATTEMPTS = 10
+
+
+class TestAsyncTcp:
+    def test_ClientSserverConnection(self) -> None:
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12345)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+        assert server._serverSocket is not None, "Server should be listening"
+
+        client = TcpClient(ctx, endpoint)
+
+        connected = False
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                connected = True
+                break
+
+        assert connected, "Connection should be established"
+        assert len(server._connections) == 1, "Server should have 1 client connection"
+        assert len(client._connections) == 1, "Client should have 1 server connection"
+
+        server.Destroy()
+        client.Destroy()
+
+    def test_DataExchange(self) -> None:
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12346)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+
+        client = TcpClient(ctx, endpoint)
+
+        testData = b"Hello Server!"
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                break
+
+        if client._connections:
+            connection = client._connections[0]
+            connection.sendBuffer.writeView[: len(testData)] = testData
+            connection.sendBuffer.size = len(testData)
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if server._connections and server._connections[0].receiveBuffer.size > 0:
+                break
+
+        assert len(server._connections) > 0
+        serverConnection = server._connections[0]
+        clientConnection = client._connections[0]
+        assert serverConnection.receiveBuffer.size > 0
+        assert clientConnection.sendBuffer.size < len(testData)
+        received_data = bytes(serverConnection.receiveBuffer.readView)
+        assert received_data == testData
+
+        server.Destroy()
+        client.Destroy()
+
+    def test_Handle_EAGAIN_OnSend(self, mocker: MockerFixture) -> None:
+        """Test EAGAIN / EWOULDBLOCK handling on send"""
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12347)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+        client = TcpClient(ctx, endpoint)
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                break
+
+        if client._connections:
+            connection = client._connections[0]
+            testData = b"Test data for EAGAIN"
+            connection.sendBuffer.writeView[: len(testData)] = testData
+            connection.sendBuffer.size = len(testData)
+
+            callCount = 0
+
+            def MockSend(data):
+                nonlocal callCount
+                callCount += 1
+                if callCount == 1:
+                    error = socket.error()
+                    error.errno = errno.EAGAIN
+                    raise error
+                elif callCount == 2:
+                    error = socket.error()
+                    error.errno = errno.EWOULDBLOCK
+                    raise error
+                else:
+                    # For the successful call, we need to return a reasonable value
+                    return len(data)
+
+            mockSocketSend = mocker.patch.object(
+                socket.socket, "send", side_effect=MockSend
+            )
+
+            # First call: EAGAIN
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert connection.closeType is None
+            assert connection.sendBuffer.size == len(testData)
+
+            # Second call: EWOULDBLOCK
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert connection.closeType is None
+            assert connection.sendBuffer.size == len(testData)
+
+            # Third call: original result (should succeed)
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert connection.sendBuffer.size == 0
+
+            assert mockSocketSend.call_count == 3
+
+        server.Destroy()
+        client.Destroy()
+
+        assert len(client._connections) == 0
+        assert len(server._connections) == 0
+
+    def test_Handle_EAGAIN_OnRecv(self, mocker: MockerFixture) -> None:
+        """Test EAGAIN / EWOULDBLOCK handling on recv_into"""
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12348)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+        client = TcpClient(ctx, endpoint)
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                break
+
+        if client._connections and server._connections:
+            clientConnection = client._connections[0]
+            test_data = b"Test data"
+            clientConnection.sendBuffer.writeView[: len(test_data)] = test_data
+            clientConnection.sendBuffer.size = len(test_data)
+
+            # Let data be sent first
+            ctx.SpinOnce(timeout=TIMEOUT)
+
+            serverConnection = server._connections[0]
+
+            callCount = 0
+
+            def MockRecvInto(buffer):
+                nonlocal callCount
+                callCount += 1
+                if callCount == 1:
+                    error = socket.error()
+                    error.errno = errno.EAGAIN
+                    raise error
+                elif callCount == 2:
+                    error = socket.error()
+                    error.errno = errno.EWOULDBLOCK
+                    raise error
+                else:
+                    # For the successful call, simulate receiving some data
+                    test_response = b"response"
+                    buffer[: len(test_response)] = test_response
+                    return len(test_response)
+
+            mockSocketRecv = mocker.patch.object(
+                socket.socket, "recv_into", side_effect=MockRecvInto
+            )
+
+            # First call: EAGAIN
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert serverConnection.closeType is None
+
+            # Second call: EWOULDBLOCK
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert serverConnection.closeType is None
+
+            # Third call: should work normally
+            ctx.SpinOnce(timeout=TIMEOUT)
+            assert serverConnection.closeType is None
+
+            assert mockSocketRecv.call_count >= 2
+
+        server.Destroy()
+        client.Destroy()
+
+    def test_DynamicServerClientAddRemoval(self) -> None:
+        """Test dynamic addition and removal of servers and clients"""
+        ctx = TcpContext()
+
+        serverEndpoint = ("127.0.0.1", 12349)
+        server = TcpServer(ctx, serverEndpoint)
+        server._EnsureServerSocket()
+
+        clients: list[TcpClient] = []
+        for i in range(3):
+            client = TcpClient(ctx, serverEndpoint)
+            clients.append(client)
+
+            for _ in range(MAX_RETRY_ATTEMPTS):
+                ctx.SpinOnce(timeout=TIMEOUT)
+                if len(client._connections) > 0:
+                    break
+
+            assert len(server._connections) == i + 1, (
+                f"After adding client {i}, server should have {i + 1} connections"
+            )
+
+        for i in range(3):
+            client = clients.pop()
+            client.Destroy()
+
+            for _ in range(MAX_RETRY_ATTEMPTS):
+                ctx.SpinOnce(timeout=TIMEOUT)
+
+            expectedConnections = 3 - i - 1
+            assert len(server._connections) == expectedConnections, (
+                f"After removing client, server should have {expectedConnections} connections"
+            )
+
+        server2Endpoint = ("127.0.0.1", 12350)
+        server2 = TcpServer(ctx, server2Endpoint)
+        server2._EnsureServerSocket()
+
+        client1 = TcpClient(ctx, serverEndpoint)
+        client2 = TcpClient(ctx, server2Endpoint)
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if (
+                len(server._connections) > 0
+                and len(server2._connections) > 0
+                and len(client1._connections) > 0
+                and len(client2._connections) > 0
+            ):
+                break
+
+        assert len(server._connections) == 1, "Original server should have 1 connection"
+        assert len(server2._connections) == 1, "New server should have 1 connection"
+
+        # Remove first server while keeping second
+        server.Destroy()
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+
+        # Second server should still work
+        assert len(server2._connections) == 1, (
+            "Second server should still have its connection"
+        )
+        assert len(client2._connections) == 1, (
+            "Client to second server should still be connected"
+        )
+
+        # Cleanup
+        client1.Destroy()
+        client2.Destroy()
+        server2.Destroy()
+
+    def test_BufferCapacityExpansion(self) -> None:
+        """Test automatic buffer capacity expansion when receive buffer is full"""
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12360)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+        client = TcpClient(ctx, endpoint)
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) > 0 and len(client._connections) > 0:
+                break
+
+        assert len(server._connections) > 0, "Server should have connection"
+        serverConnection = server._connections[0]
+
+        initialCapacity = serverConnection.receiveBuffer.capacity
+        serverConnection.receiveBuffer.size = initialCapacity
+
+        ctx.SpinOnce(timeout=TIMEOUT)
+
+        assert serverConnection.receiveBuffer.capacity == initialCapacity * 2, (
+            f"Buffer capacity should be doubled from {initialCapacity} to {initialCapacity * 2}, "
+            f"got {serverConnection.receiveBuffer.capacity}"
+        )
+
+        server.Destroy()
+        client.Destroy()
+
+    def test_MultipleSimultaneousAccepts(self) -> None:
+        """Test server handling multiple simultaneous connection attempts"""
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12361)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+
+        clients = []
+        for i in range(5):
+            client = TcpClient(ctx, endpoint)
+            clients.append(client)
+
+        connectionsSeen = set()
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+
+            currentConnections = set()
+            for conn in server._connections:
+                if conn.connectionSocket:
+                    currentConnections.add(id(conn.connectionSocket))
+
+            connectionsSeen.update(currentConnections)
+
+            # Check if all clients are connected
+            if len(server._connections) == 5 and all(
+                len(c._connections) > 0 for c in clients
+            ):
+                break
+
+        assert len(server._connections) == 5, (
+            f"Expected 5 connections, got {len(server._connections)}"
+        )
+        assert len(connectionsSeen) == 5, (
+            f"Expected 5 unique connections, saw {len(connectionsSeen)}"
+        )
+
+        for i, client in enumerate(clients):
+            assert len(client._connections) == 1, f"Client {i} should have 1 connection"
+
+        for client in clients:
+            client.Destroy()
+        server.Destroy()
+
+    def test_MultipleServersMultipleClients(self) -> None:
+        """Test multiple servers with multiple clients connecting to each"""
+        SERVER_COUNT = 10
+        CLIENT_PER_SERVER = 5
+        ctx = TcpContext()
+
+        assert ctx._selector
+
+        servers: list[TcpServer] = []
+        for i in range(SERVER_COUNT):
+            endpoint = ("127.0.0.1", 12351 + i)
+            server = TcpServer(ctx, endpoint)
+            server._EnsureServerSocket()
+            servers.append(server)
+
+        clients: list[TcpClient] = []
+        for server in servers:
+            for _ in range(CLIENT_PER_SERVER):
+                client = TcpClient(ctx, server._endpoint)
+                clients.append(client)
+
+        initialRegisteredSockets = len(ctx._selector.get_map())
+
+        # Process CLIENT_PER_SERVER clients at a time
+        for i in range(0, len(clients), CLIENT_PER_SERVER):
+            for _ in range(MAX_RETRY_ATTEMPTS):
+                ctx.SpinOnce(timeout=TIMEOUT)
+
+            # The number of registered sockets should grow as connections are added
+            currentRegistered = len(ctx._selector.get_map())
+            assert currentRegistered >= initialRegisteredSockets, (
+                "Registered sockets should increase or stay same"
+            )
+
+        totalConnections = sum(len(server._connections) for server in servers)
+        assert totalConnections == SERVER_COUNT * CLIENT_PER_SERVER, (
+            f"Expected {SERVER_COUNT * CLIENT_PER_SERVER} total connections, got {totalConnections}"
+        )
+
+        finalRegistered = len(ctx._selector.get_map())
+        expectedSockets = SERVER_COUNT + totalConnections
+        assert finalRegistered >= expectedSockets, (
+            f"Should have at least {expectedSockets} registered sockets, got {finalRegistered}"
+        )
+
+        testData = b"Multi server/client test data"
+        messagesSent = 0
+
+        # Send data from last client for each server to create mixed read/write activity
+        for i in range(0, len(clients), CLIENT_PER_SERVER):
+            client = clients[i]
+            if client._connections:
+                conn = client._connections[0]
+                conn.sendBuffer.writeView[: len(testData)] = testData
+                conn.sendBuffer.size = len(testData)
+                messagesSent += 1
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+
+        messages_received = 0
+        for server in servers:
+            for conn in server._connections:
+                if conn.receiveBuffer.size > 0:
+                    messages_received += 1
+
+        assert messages_received == messagesSent, (
+            f"Expected {messagesSent} messages received, got {messages_received}"
+        )
+
+        for client in clients:
+            client.Destroy()
+
+        for server in servers:
+            server.Destroy()
+
+    def test_ConnectionCleanupDuringDestroy(self) -> None:
+        """Test proper cleanup when servers/clients are destroyed with active connections"""
+        ctx = TcpContext()
+        endpoint = ("127.0.0.1", 12362)
+
+        server = TcpServer(ctx, endpoint)
+        server._EnsureServerSocket()
+        clients: list[TcpClient] = []
+
+        for _ in range(3):
+            client = TcpClient(ctx, endpoint)
+            clients.append(client)
+
+        for _ in range(MAX_RETRY_ATTEMPTS):
+            ctx.SpinOnce(timeout=TIMEOUT)
+            if len(server._connections) == 3 and all(
+                len(c._connections) > 0 for c in clients
+            ):
+                break
+
+        assert len(server._connections) == 3, "Should have 3 server connections"
+
+        testData = b"Test data before cleanup"
+        for client in clients:
+            if client._connections:
+                conn = client._connections[0]
+                conn.sendBuffer.writeView[: len(testData)] = testData
+                conn.sendBuffer.size = len(testData)
+
+        ctx.SpinOnce(timeout=TIMEOUT)
+
+        initRegisteredSocketCount = len(ctx._selector.get_map()) if ctx._selector else 0
+
+        server.Destroy()
+        assert len(server._connections) == 0, (
+            "Server should have no connections after destroy"
+        )
+
+        finalRegisteredSocketCount = (
+            len(ctx._selector.get_map()) if ctx._selector else 0
+        )
+        assert finalRegisteredSocketCount < initRegisteredSocketCount, (
+            f"Selector should have fewer sockets after cleanup: {finalRegisteredSocketCount} < {initRegisteredSocketCount}"
+        )
+
+        for client in clients:
+            client.Destroy()
+            assert len(client._connections) == 0, (
+                "Client should have no connections after destroy"
+            )


### PR DESCRIPTION
Reopens https://github.com/mujin/mujinasyncpy/pull/7

- Use selector module instead of select, fix FD_SETSIZE limitation. The selector.DefaultSelector() will try to use epoll if avaliable.
- Remove xsockets and xlist since we are using selector module, there is no handler for xlist
- Add error check when calling wsocket.send(), when encounter EAGAIN or EWOULDBLOCK, we should not close the socket.
- Tweak typing in asynctcp.py, now pyright won't give any typing error in this file
Add test code