### PR TITLE
Have pyright check python subdir

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+    "extraPaths": ["python"]
+}


### PR DESCRIPTION
pyright checks the modules relative to the directory setup.py, so if setup.py is put to top-level (not python subdir), the python subdir must be taught via pyrightconfig.json.

Initially reported by @eisoku9618 